### PR TITLE
Workaround for circleCI DeadKernelError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
           name: Build HTML rendering of notebooks
           no_output_timeout: 30m
           command: |
+            # Ugly workaround https://github.com/Caltech-IPAC/irsa-tutorials/issues/6
+            sed -ie 's|nb_execution_excludepatterns = \[|nb_execution_excludepatterns = \["wise-allwise-catalog-demo.md", |g' conf.py
             python -m tox -e py312-buildhtml
 
       - store_artifacts:

--- a/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
+++ b/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
@@ -42,7 +42,8 @@ Each method accesses the parquet files a bit differently and is useful for diffe
 ## Imports
 
 ```{code-cell} ipython3
-!pip install -r requirements.txt
+# Uncomment the following if you have missing dependencies.
+# !pip install numpy pandas>=1.5.2 pyarrow>=10.0.1 matplotlib hpgeom astropy
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Somehow this notebook causes a kernel error in circleCI. I cannot reproduce it locally, nor GHA has problems. 
Either way, some workaround will need to be in place so we have a passing build status for the other notebooks.