### PR TITLE
CI: enable firefly osx

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -53,6 +53,4 @@ jobs:
       run: python -m pip install --upgrade tox
 
     - name: Test with tox
-      run: |
-        # Workaround for OSX for https://jira.ipac.caltech.edu/browse/FIREFLY-1528
-        tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}

--- a/ignore_osx_testing
+++ b/ignore_osx_testing
@@ -1,2 +1,1 @@
-tutorials/firefly
 tutorials/parallelize/Parallelize_Convolution

--- a/tutorials/requirements.txt
+++ b/tutorials/requirements.txt
@@ -15,5 +15,3 @@ firefly-client
 jupyter-firefly-extensions
 # For supporting myst-based notebooks
 jupytext
-# For firefly-client packaging bug
-setuptools


### PR DESCRIPTION
This is to test the fix from https://github.com/Caltech-IPAC/firefly_client/pull/61

More context: https://github.com/Caltech-IPAC/irsa-tutorials/pull/10#issuecomment-2263766740 and below

cc @jaladh-singhal 