### PR TITLE
ENH: adding conditional to test execution

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: tox -e py311-buildhtml
 
       - name: Publish
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847  # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/html/

--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   tests:
+    # Do not run the test matrix on PRs affecting the rendering
+    if: ${{! (github.event_name == 'pull_request' && !contains(github.event.pull_requiest.label.*.name, 'html rendering')) }}
+
     name: ${{ matrix.os }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
The is no need to run the test matrix for PRs like #25 

I would even go as far as there is no need to execute the notebooks for such PRs in circleCI, however it sounds a bit hacky and ugly how such a workaround can be added there (as I see there isn't an easy way to get access to the github labels to write such a conditional there just outstanding feature requests such as https://ideas.circleci.com/cloud-feature-requests/p/provide-github-labels-for-filtering, and even then we need to sed nb_execution_mode to be off in the tox config before it is being picked up by the runner...)