### PR TITLE
HTML: restructure index page headings

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   tests:
     # Do not run the test matrix on PRs affecting the rendering
-    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_requiest.label.*.name, 'html rendering') }}
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'html rendering') }}
 
     name: ${{ matrix.os }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey
 ## Interactive visualization in Python with Firefly
 
 These notebooks demonstrate how to use the Firefly visualization tools from Python. 
-Firefly is an open-source toolkit based on IVOA standards and designed to enable astronomical data archive access, exploratory data analysis, and visualization. 
+[Firefly](https://github.com/Caltech-IPAC/firefly) is an open-source toolkit based on IVOA standards and designed to enable astronomical data archive access, exploratory data analysis, and visualization. 
 
 It is used in archive user interfaces at IRSA, the NASA Exoplanet Science Institute (NExScI), the NASA/IPAC Extragalactic Database (NED), and the Vera C. Rubin Observatory.
 

--- a/index.md
+++ b/index.md
@@ -1,18 +1,16 @@
-# Caltech/IPAC -- IRSA notebooks
+# Caltech/IPAC--IRSA Python Notebook Tutorials
 
 
-These Jupyter Notebook tutorials demonstrate access methods and techniques for working with data served by IRSA.
-They cover topics like querying IRSA, working with catalogs in Parquet format, and general parallelization techniques.
+These Python Jupyter Notebook tutorials demonstrate access methods and techniques for working with data served by the NASA/IPAC Infrared Science Archive (IRSA).
+They cover topics like querying IRSA, working with catalogs in Parquet format, visualizing with Firefly, and general other techniques.
 
 
-## Accessing IRSA's on Premises Holding using VO protocols
-
-These notebooks use the tools: PyVO, Astropy.
+## Accessing IRSA's on-premises holdings using VO protocols
 
 ```{toctree}
 ---
 maxdepth: 1
-caption: IRSA's on premises
+caption: VO on-prem data access
 ---
 tutorials/irsa-sia-examples/sia_2mass_allsky
 tutorials/irsa-sia-examples/sia_allwise_atlas
@@ -22,18 +20,15 @@ tutorials/cosmodc2/cosmoDC2_TAP_access.md
 
 ```
 
-## Accessing IRSA's Cloud Holdings
+## Accessing IRSA's cloud holdings
 
-These notebooks demonstrate basic access to the IRSA-curated datasets available in AWS S3 cloud storage buckets.
-They show examples for the Parquet version of the AllWISE Source Catalog, located in AWS S3 cloud storage and the exploration of simulated Roman observations store in AWS S3 cloud storage.
-
-They use the tools: Pandas, PyArrow, Astropy, Astroquery, PyVO, S3FS, matplotlib
+These notebooks demonstrate how to access the IRSA-curated datasets that available in Amazon Web Services (AWS) S3 cloud storage buckets.
 
 
 ```{toctree}
 ---
 maxdepth: 1
-caption: IRSA in the cloud
+caption: Cloud data access
 ---
 
 tutorials/cloud_access/cloud-access-intro
@@ -44,7 +39,12 @@ tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey
 ```
 
 
-## Interactive Visualization in Python with Firefly
+## Interactive visualization in Python with Firefly
+
+These notebooks demonstrate how to use the Firefly visualization tools from Python. 
+Firefly is an open-source toolkit based on IVOA standards and designed to enable astronomical data archive access, exploratory data analysis, and visualization. 
+
+It is used in archive user interfaces at IRSA, the NASA Exoplanet Science Institute (NExScI), the NASA/IPAC Extragalactic Database (NED), and the Vera C. Rubin Observatory.
 
 ```{toctree}
 ---
@@ -58,12 +58,14 @@ tutorials/firefly/NEOWISE_light_curve_demo
 ```
 
 
-## Generally Useful Techniques
+## Generally useful techniques
+
+These notebooks  cover miscellaneous topics that users might find useful in their analysis of IRSA-curated data.
 
 ```{toctree}
 ---
 maxdepth: 1
-caption: Generic Techniques
+caption: Generic techniques
 ---
 
 tutorials/parallelize/Parallelize_Convolution

--- a/index.md
+++ b/index.md
@@ -5,44 +5,51 @@ These Jupyter Notebook tutorials demonstrate access methods and techniques for w
 They cover topics like querying IRSA, working with catalogs in Parquet format, and general parallelization techniques.
 
 
-## Accessing IRSA archive holdings
+## Accessing IRSA's on Premises Holding using VO protocols
 
-### Image Thumbnailes
-
-These notebooks show how to query IRSA's image services, inspect the results, and download and visualize images.
-
-They use the tools: PyVO, Astropy.
+These notebooks use the tools: PyVO, Astropy.
 
 ```{toctree}
 ---
 maxdepth: 1
+caption: IRSA's on premises
 ---
-
 tutorials/irsa-sia-examples/sia_2mass_allsky
 tutorials/irsa-sia-examples/sia_allwise_atlas
 tutorials/irsa-sia-examples/sia_cosmos
 tutorials/irsa-sia-examples/siav2_seip
-
-```
-
-### Catalogs
-
-```{toctree}
----
-maxdepth: 1
----
-
 tutorials/cosmodc2/cosmoDC2_TAP_access.md
 
 ```
 
+## Accessing IRSA's Cloud Holdings
 
+These notebooks demonstrate basic access to the IRSA-curated datasets available in AWS S3 cloud storage buckets.
+They show examples for the Parquet version of the AllWISE Source Catalog, located in AWS S3 cloud storage and the exploration of simulated Roman observations store in AWS S3 cloud storage.
 
-## Visualizations with Firefly
+They use the tools: Pandas, PyArrow, Astropy, Astroquery, PyVO, S3FS, matplotlib
+
 
 ```{toctree}
 ---
 maxdepth: 1
+caption: IRSA in the cloud
+---
+
+tutorials/cloud_access/cloud-access-intro
+tutorials/parquet-catalog-demos/wise-allwise-catalog-demo
+tutorials/openuniversesims/openuniverse2024_roman_simulated_timedomainsurvey
+tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey
+
+```
+
+
+## Interactive Visualization in Python with Firefly
+
+```{toctree}
+---
+maxdepth: 1
+caption: Visualizations with Firefly
 ---
 
 tutorials/firefly/SEDs_in_Firefly
@@ -51,56 +58,12 @@ tutorials/firefly/NEOWISE_light_curve_demo
 ```
 
 
-
-## IRSA in the cloud
-
-This notebook demonstrates basic access to the IRSA-curated datasets available in AWS S3 cloud storage buckets.
-
-It uses the tools: Pandas, PyArrow, Astropy, Astroquery, PyVO, S3FS
+## Generally Useful Techniques
 
 ```{toctree}
 ---
 maxdepth: 1
----
-
-tutorials/cloud_access/cloud-access-intro
-```
-
-### Catalogs
-
-This notebook shows examples for the Parquet version of the AllWISE Source Catalog, located in AWS S3 cloud storage.
-It uses the tools: Pandas, PyArrow, Astropy
-
-
-```{toctree}
----
-maxdepth: 1
----
-
-tutorials/parquet-catalog-demos/wise-allwise-catalog-demo
-
-```
-
-### Explore OpenUniverse 2024 Data Preview
-
-These notebooks explore simulared Roman observation stored in AWS S3 cloud storage.
-They use the tools: Pandas, Astropy, S3FS, matplotlib, NumPy
-
-```{toctree}
----
-maxdepth: 1
----
-
-tutorials/openuniversesims/openuniverse2024_roman_simulated_timedomainsurvey
-tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey
-
-```
-
-## Generally useful techniques
-
-```{toctree}
----
-maxdepth: 1
+caption: Generic Techniques
 ---
 
 tutorials/parallelize/Parallelize_Convolution

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,8 @@ commands =
     !buildhtml: pytest --nbval-lax -vv --durations=10 tutorials
     buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nT --keep-going
     # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
-    buildhtml: sed -Ei '/caption-text/{N; s/.+caption-text.+\s<ul>/<ul>/; P;D}' _build/html/index.html
+    buildhtml: sed -E -i.bak '/caption-text/{N; s/.+caption-text.+\n<ul>/<ul>/; P;D;}' _build/html/index.html
+    buildhtml: bash -c 'rm _build/html/index.html.bak'
 
 pip_pre =
     predeps: true

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     devdeps: astropy>0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
-allowlist_externals = bash
+allowlist_externals = bash, sed
 
 commands =
     pip freeze
@@ -41,6 +41,8 @@ commands =
 
     !buildhtml: pytest --nbval-lax -vv --durations=10 tutorials
     buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nT --keep-going
+    # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
+    buildhtml: sed -Ei '/caption-text/{N; s/.+caption-text.+\s<ul>/<ul>/; P;D}' _build/html/index.html
 
 pip_pre =
     predeps: true

--- a/tutorials/cloud_access/cloud-access-intro.md
+++ b/tutorials/cloud_access/cloud-access-intro.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# IRSA Cloud Access Introduction
+# IRSA cloud access introduction
 
 This is the introductory tutorial demonstrating basic python access to the IRSA-curated images and catalogs available in AWS S3 cloud storage buckets.
 

--- a/tutorials/cosmodc2/cosmoDC2_TAP_access.md
+++ b/tutorials/cosmodc2/cosmoDC2_TAP_access.md
@@ -14,7 +14,7 @@ kernelspec:
 
 
 
-# CosmoDC2 Mock v1 catalogs with IRSA TAP
+# Querying CosmoDC2 Mock v1 catalogs
 
 This tutorial demonstrates how to access the CosmoDC2 Mock V1 catalogs. More information about these catalogs can be found here: https://irsa.ipac.caltech.edu/Missions/cosmodc2.html
 

--- a/tutorials/firefly/NEOWISE_light_curve_demo.md
+++ b/tutorials/firefly/NEOWISE_light_curve_demo.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Using Firefly visualization tools to understand the Light Curves of Solar System Objects
+# Using Firefly visualization tools to understand the light curves of Solar System objects
 
 ## Learning Goals
 

--- a/tutorials/firefly/NEOWISE_light_curve_demo.md
+++ b/tutorials/firefly/NEOWISE_light_curve_demo.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Finding Light Curves of Solar System Objects
+# Using Firefly visualization tools to understand the Light Curves of Solar System Objects
 
 ## Learning Goals
 

--- a/tutorials/firefly/SEDs_in_Firefly.md
+++ b/tutorials/firefly/SEDs_in_Firefly.md
@@ -11,12 +11,6 @@ kernelspec:
   name: python3
 ---
 
-
-+++
-
-***
-
-+++
 # Using Firefly visualization tools in Python to vet SEDs
 
 ## Learning Goals

--- a/tutorials/firefly/SEDs_in_Firefly.md
+++ b/tutorials/firefly/SEDs_in_Firefly.md
@@ -11,13 +11,13 @@ kernelspec:
   name: python3
 ---
 
-# Vetting SEDs in Firefly
 
 +++
 
 ***
 
 +++
+# Using Firefly visualization tools in Python to vet SEDs
 
 ## Learning Goals
 

--- a/tutorials/irsa-sia-examples/sia_2mass_allsky.md
+++ b/tutorials/irsa-sia-examples/sia_2mass_allsky.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# 2MASS All-Sky Atlas
+# Searching for 2MASS All-Sky Atlas Images
 
 This notebook tutorial demonstrates the process of querying IRSA's Simple Image Access (SIA) service for the 2MASS All-Sky Atlas, making a cutout image (thumbnail), and displaying the cutout.
 

--- a/tutorials/irsa-sia-examples/sia_allwise_atlas.md
+++ b/tutorials/irsa-sia-examples/sia_allwise_atlas.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# AllWISE Atlas Images
+# Searching for AllWISE Atlas Images
 
 +++
 

--- a/tutorials/irsa-sia-examples/sia_cosmos.md
+++ b/tutorials/irsa-sia-examples/sia_cosmos.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# COSMOS
+# Searching for contributed COSMOS images
 
 +++
 

--- a/tutorials/irsa-sia-examples/siav2_seip.md
+++ b/tutorials/irsa-sia-examples/siav2_seip.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Spitzer Enhanced Imaging Products
+# Searching for Spitzer Enhanced Imaging Products
 
 +++
 

--- a/tutorials/openuniversesims/openuniverse2024_roman_simulated_timedomainsurvey.md
+++ b/tutorials/openuniversesims/openuniverse2024_roman_simulated_timedomainsurvey.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Simulated Roman Time Domain Survey Data
+# Analyzing cloud-hosted simulated Roman Time Domain Survey images
 
 +++
 

--- a/tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey.md
+++ b/tutorials/openuniversesims/openuniverse2024_roman_simulated_wideareasurvey.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Simulated Roman Coadds
+# Analyzing cloud-hosted simulated Roman coadded images
 
 +++
 

--- a/tutorials/parallelize/Parallelize_Convolution.md
+++ b/tutorials/parallelize/Parallelize_Convolution.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Parallelizing Image Convolution
+# Parallelizing image convolution
 
 +++
 

--- a/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
+++ b/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# AllWISE Source Catalog Examples
+# Analyzing cloud-hosted AllWISE Source Catalog in Parquet format
 
 +++
 


### PR DESCRIPTION
This also adds top level headings as captions to the sidebar. Downside of this workaround is that those are not linked to the achors, so it's not possible to use them to navigate back. It also won't work once we add one more layer of headings in the index page (like it was in the first draft, before this PR)

I saw some other workarounds, so can keep experimenting if we