### PR TITLE
CI: fail rendering job on errors

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,6 +7,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import platform
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -39,12 +40,17 @@ exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache', 'README.
 # MyST-NB configuration
 nb_execution_timeout = 900
 
+nb_execution_excludepatterns = []
+
 if 'CIRCLECI' in os.environ:
     # Workaround for https://github.com/Caltech-IPAC/irsa-tutorials/issues/6
     # Some of the notebooks run into a DeadKernelError on CircleCI, but do execute and render on GHA.
     # Ignore them here.
-    nb_execution_excludepatterns = ['wise-allwise-catalog-demo.md', 'Parallelize_Convolution.md']
+    nb_execution_excludepatterns += ['wise-allwise-catalog-demo.md', 'Parallelize_Convolution.md']
 
+if platform.platform().startswith("mac") or platform.platform().startswith("win"):
+    # The way the notebooks use the multiprocessing module is known to not work on non-Linux
+    nb_execution_excludepatterns += ['Parallelize_Convolution.md']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
     !buildhtml: bash -c 'find tutorials -name "*.md" | grep -vf ignore_testing | xargs jupytext --to notebook '
 
     !buildhtml: pytest --nbval-lax -vv --durations=10 tutorials
-    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nT --keep-going
+    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nWT --keep-going
     # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
     buildhtml: sed -E -i.bak '/caption-text/{N; s/.+caption-text.+\n<ul>/<ul>/; P;D;}' _build/html/index.html
     buildhtml: bash -c 'rm _build/html/index.html.bak'


### PR DESCRIPTION
Rendering job should now fail on tracebacks. Also added OSX and Windows rendering exception