### PR TITLE
ENH: merge streams for nicer looking outputs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,7 @@ exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache', 'README.
 
 # MyST-NB configuration
 nb_execution_timeout = 900
+nb_merge_streams = True
 
 nb_execution_excludepatterns = []
 


### PR DESCRIPTION
This would make some of the tutorial renderings nicer, e.g. the openuniverse timeseries (but I see it improved a few others, too): 

<img width="1019" alt="Screenshot 2024-09-19 at 14 39 39" src="https://github.com/user-attachments/assets/77511cb9-0777-4374-b285-079dda76a8bb">

vs



<img width="944" alt="Screenshot 2024-09-19 at 14 40 05" src="https://github.com/user-attachments/assets/7f9c9db2-f85d-4cd8-ad04-bc4ed10b4031">
