### PR TITLE
CI: fix skip label CI skip and ignore all euclid testing for now

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   tests:
     # Do not run the test matrix on PRs affecting the rendering
-    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'html rendering') }}
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'html rendering / skip testing') }}
 
     name: ${{ matrix.os }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/conf.py
+++ b/conf.py
@@ -57,6 +57,9 @@ if platform.platform().startswith("mac") or platform.platform().startswith("win"
     # The way the notebooks use the multiprocessing module is known to not work on non-Linux
     nb_execution_excludepatterns += ['Parallelize_Convolution.md', 'neowise-source-table-lightcurves.md']
 
+# Euclid data is not yet available publicly
+nb_execution_excludepatterns += ['*Euclid*', '*euclid*']
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/conf.py
+++ b/conf.py
@@ -60,6 +60,8 @@ if platform.platform().startswith("mac") or platform.platform().startswith("win"
 # Euclid data is not yet available publicly
 nb_execution_excludepatterns += ['*Euclid*', '*euclid*']
 
+exclude_patterns += ['tutorials/*/*[Ee]uclid*']
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/ignore_gha_testing
+++ b/ignore_gha_testing
@@ -1,3 +1,3 @@
 tutorials/parquet-catalog-demos/neowise-source-table-lightcurves
 tutorials/parquet-catalog-demos/neowise-source-table-strategies
-tutorials/euclid_access
+euclid


### PR DESCRIPTION
fixes #51, the logic broke when I renamed the label.