### PR TITLE
Euclid: Use copy-on-write to avoid SettingWithCopyWarning

### DIFF
--- a/tutorials/euclid_access/1_Euclid_intro_MER_images.md
+++ b/tutorials/euclid_access/1_Euclid_intro_MER_images.md
@@ -84,6 +84,9 @@ from astropy import units as u
 
 import pyvo as vo
 import sep
+
+# Copy-on-write is more performant and avoids unexpected modifications of the original DataFrame.
+pd.options.mode.copy_on_write = True
 ```
 
 ## 1. Search for multiwavelength Euclid Q1 MER mosaics that cover the star HD 168151


### PR DESCRIPTION
The notebook 1_Euclid_intro_MER_images is displaying a pandas warning like:

```
SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
```

from a cell about 2/3 the way down that gets the `filters`. This PR adds `pd.options.mode.copy_on_write = True` to the top of the notebook to avoid this. Copy-on-write avoids unexpected modifications to the original DataFrame, is generally more performant, and will become the default in pandas 3.0.