### PR TITLE
CI: add all the versions for the oldestjob

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,11 +1,11 @@
 # For the content of the tutorials
 tqdm
-numpy
-matplotlib
-astropy
+numpy>=1.24
+matplotlib>=3.7
+astropy>=5.3
 pyvo>=1.5
 astroquery>=0.4.10
-scipy
+scipy>=1.10
 pyarrow>=10.0.1
 hpgeom
 pandas>=1.5.2
@@ -16,7 +16,7 @@ s3fs
 firefly-client>=3.2.0
 jupyter-firefly-extensions
 reproject
-photutils
+photutils>=2.0
 fsspec
 sep>=1.4
 # For supporting myst-based notebooks

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -11,7 +11,7 @@ hpgeom
 pandas>=1.5.2
 dask[distributed]
 psutil
-ray
+ray ; python_version < "3.13"
 s3fs
 firefly-client>=3.2.0
 jupyter-firefly-extensions

--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -32,14 +32,14 @@ jobs:
         name: ['with Python 3.12',]
 
         include:
-          - python-version: '3.9'
-            toxenv: py39-test-oldestdeps
-            name: with Python 3.9 and oldest versioned dependencies
+          - python-version: '3.10'
+            toxenv: py310-test-oldestdeps
+            name: with Python 3.10 and oldest versioned dependencies
             os: ubuntu-latest
 
-          - python-version: '3.12'
-            toxenv: py312-test-devdeps
-            name: with Python 3.12 and developer versioned dependencies
+          - python-version: '3.13'
+            toxenv: py313-test-devdeps
+            name: with Python 3.13 and developer versioned dependencies
             os: ubuntu-latest
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,8 @@ commands =
     # too due to issues with e.g. multiprocessing and problems in upstream dependency
     !buildhtml: bash -c 'if python -c "import platform; print(platform.platform())" | grep -i macos; then cat ignore_osx_testing >> ignore_testing; fi'
     !buildhtml: bash -c 'if python -c "import platform; print(platform.platform())" | grep -i win; then cat ignore_windows_testing >> ignore_testing; fi'
+    # ray is not yet python 3.13 compatible
+    !buildhtml: bash -c 'if python -c "import sys; print(sys.version)" | grep 3.13; then echo Parallelize_Convolution.md >> ignore_testing; fi'
     !buildhtml: bash -c 'if [[ $CI == true ]]; then cat ignore_gha_testing >> ignore_testing; fi'
     !buildhtml: bash -c 'find tutorials -name "*.md" | grep -vf ignore_testing | xargs jupytext --to notebook '
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
 
     devdeps: astropy>0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
+    devdeps: git+https://github.com/astropy/astroquery.git#egg=astroquery
 
 allowlist_externals = bash, sed
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+    py{310, 311, 312, 313}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
 requires =
     pip >= 19.3.1
 
@@ -21,10 +21,18 @@ deps =
     -rsite_requirements.txt
     -r.binder/requirements.txt
 
-    # TODO: add the oldest supported versions of all the dependencies here
-    # oldestdeps: numpy==1.18
-    # oldestdeps: matplotlib==3.1.2
-    # oldestdeps: scipy==1.4
+    # Notebooks sets minimums for photutils, astroquery, sep, pyvo, pandas;
+    # the rest is indirect minimums for those
+    oldestdeps: numpy==1.24.0
+    oldestdeps: matplotlib==3.7.0
+    oldestdeps: scipy==1.10.0
+    oldestdeps: astropy==5.3.0
+    oldestdeps: photutils==2.0.0
+    oldestdeps: astroquery==0.4.10
+    oldestdeps: firefly_client==3.2.0
+    oldestdeps: sep==1.4.0
+    oldestdeps: pyvo==1.5.0
+    oldestdeps: pandas==1.5.2
 
     devdeps: astropy>0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo


### PR DESCRIPTION
Apparently, this was never set up properly and as the latest notebooks run into issues with old versions I added minimums for all the main dependencies.