### PR TITLE
CI: fixing test status when no notebooks were collected for testing

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest
 nbval
+pytest-custom_exit_code

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
     # We only want to run CI in PRs for the notebooks we touched
     !buildhtml: bash -c 'if [[ $GITHUB_EVENT_NAME == pull_request ]]; then git fetch origin main --depth=1; git diff origin/main --name-only tutorials | grep .md; else find tutorials -name "*.md"; fi | grep -vf ignore_testing | xargs jupytext --to notebook '
 
-    !buildhtml: pytest --nbval-lax -vv --durations=10 tutorials
+    !buildhtml: pytest --nbval-lax -vv --suppress-no-test-exit-code --durations=10 tutorials
     buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nWT --keep-going
     # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
     buildhtml: sed -E -i.bak '/caption-text/{N; s/.+caption-text.+\n<ul>/<ul>/; P;D;}' _build/html/index.html


### PR DESCRIPTION
This should fix #79 

Note that I push the commits in sequence, the first one is expected too fail the GHA tests, and with the second one we should get a green pass. I'll ignore circleCI status here.