### PR TITLE
MAINT: using longer timeout to accommodate cosmodc2 async query

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,7 +42,7 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache', 'README.md']
 
 # MyST-NB configuration
-nb_execution_timeout = 900
+nb_execution_timeout = 1200
 nb_merge_streams = True
 
 nb_execution_excludepatterns = []


### PR DESCRIPTION
We do hit timeouts on the cosmodc2 notebook, and while I'm fairly certain switching to async query solved the server side timeout, we now hit the notebook execution timeout of 900s. 

So hopefully, this trick will provide a workaround, and in the meantime I'll work out how to properly use a cache between CI runs.