### PR TITLE
DOC: adding note about having recent enough versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ data/
 output/
 # "cache" dir is created by nway in the forced photometry notebook. ignore it and any other "cache" directory
 cache/
+# Other random download/output dirs, etc, these should ideally be generalized to be one of the aboves
+downloaded_hdf5_files/
 
 # Data and Output files
 # data and output files should not be committed to the code repository
@@ -21,6 +23,7 @@ cache/
 *.parquet
 *.pdf
 *.png
+*.gif
 
 # Tests and reports
 htmlcov/
@@ -32,6 +35,7 @@ htmlcov/
 .ipynb_checkpoints
 *.ipynb
 _build/
+
 
 # PyCharm
 .idea

--- a/tutorials/cloud_access/euclid-cloud-access.md
+++ b/tutorials/cloud_access/euclid-cloud-access.md
@@ -42,9 +42,13 @@ If you have questions, please contact the [IRSA helpdesk](https://irsa.ipac.calt
 ## 2. Imports
 - `s3fs` for browsing S3 buckets
 - `astropy` for handling coordinates, units, FITS I/O, tables, images, etc.
-- `astroquery` for querying Euclid data products from IRSA
+- `astroquery>=0.4.10` for querying Euclid data products from IRSA
 - `matplotlib` for visualization
 - `json` for decoding JSON strings
+
+```{important}
+We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+```
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.

--- a/tutorials/cloud_access/euclid-cloud-access.md
+++ b/tutorials/cloud_access/euclid-cloud-access.md
@@ -47,7 +47,7 @@ If you have questions, please contact the [IRSA helpdesk](https://irsa.ipac.calt
 - `json` for decoding JSON strings
 
 ```{important}
-We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+We rely on ``astroquery`` features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/1_Euclid_intro_MER_images.md
+++ b/tutorials/euclid_access/1_Euclid_intro_MER_images.md
@@ -57,7 +57,7 @@ Each MER image is approximately 1.47 GB. Downloading can take some time.
 ## Imports
 
 ```{important}
-We rely on astroquery and sep features that have been recently added, so please make sure you have the respective version v0.4.10 and v1.4 or newer installed.
+We rely on ``astroquery`` and ``sep`` features that have been recently added, so please make sure you have the respective version v0.4.10 and v1.4 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/1_Euclid_intro_MER_images.md
+++ b/tutorials/euclid_access/1_Euclid_intro_MER_images.md
@@ -56,6 +56,10 @@ Each MER image is approximately 1.47 GB. Downloading can take some time.
 
 ## Imports
 
+```{important}
+We rely on astroquery and sep features that have been recently added, so please make sure you have the respective version v0.4.10 and v1.4 or newer installed.
+```
+
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
 # !pip install numpy 'astropy>=5.3' matplotlib 'astroquery>=0.4.10' 'sep>=1.4' fsspec

--- a/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
+++ b/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
@@ -48,6 +48,10 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 
 ## Imports
 
+```{important}
+We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+```
+
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed
 # !pip install numpy matplotlib 'astroquery>=0.4.10'
@@ -101,7 +105,7 @@ The MER catalog contains 476 columns, below are a few highlights:
 
 ### Define the following ADQL query to find the first 10k stars in the MER catalog
 
-Since we are just using the MER catalog alone, it does not have a column for classification. 
+Since we are just using the MER catalog alone, it does not have a column for classification.
 We can use the `point_like_flag = 1` or `point_like_prob > 0.99` for stars.
 
 Set all the fluxes to be greater than 0 so the object is detected in all four Euclid MER mosaic images.
@@ -132,7 +136,7 @@ result_stars[:5]
 - Plot the color-magnitude diagram
 
 ```{code-cell} ipython3
-mag_y = -2.5 * np.log10(result_stars["flux_y_templfit"]) + 23.9 
+mag_y = -2.5 * np.log10(result_stars["flux_y_templfit"]) + 23.9
 mag_h = -2.5 * np.log10(result_stars["flux_h_templfit"]) + 23.9
 
 x = mag_y - mag_h  # Y - H

--- a/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
+++ b/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
@@ -49,7 +49,7 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 ## Imports
 
 ```{important}
-We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+We rely on ``astroquery`` features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
+++ b/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
@@ -46,7 +46,7 @@ If you have questions about it, please contact the [IRSA helpdesk](https://irsa.
 ## Imports
 
 ```{important}
-We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+We rely on ``astroquery`` features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
+++ b/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
@@ -45,6 +45,10 @@ If you have questions about it, please contact the [IRSA helpdesk](https://irsa.
 
 ## Imports
 
+```{important}
+We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+```
+
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed
 # !pip install matplotlib astropy 'astroquery>=0.4.10'

--- a/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
+++ b/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
@@ -49,6 +49,10 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 
 ## Imports
 
+```{important}
+We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+```
+
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
 # !pip install matplotlib 'astropy>=5.3' 'astroquery>=0.4.10' fsspec firefly_client
@@ -94,7 +98,7 @@ This searches specifically in the euclid_DpdMerBksMosaic "collection" which is t
 +++
 
 ```{note}
-This table lists all MER mosaic images available in this position. These mosaics include the Euclid VIS, Y, J, H images, as well as ground-based telescopes which have been put on the same pixel scale. For more information, see the [Euclid documentation at IPAC](https://euclid.caltech.edu/page/euclid-faq-tech/). We use the ``facility`` argument below to query for Euclid images only. 
+This table lists all MER mosaic images available in this position. These mosaics include the Euclid VIS, Y, J, H images, as well as ground-based telescopes which have been put on the same pixel scale. For more information, see the [Euclid documentation at IPAC](https://euclid.caltech.edu/page/euclid-faq-tech/). We use the ``facility`` argument below to query for Euclid images only.
 ```
 
 ```{code-cell} ipython3
@@ -217,7 +221,7 @@ result_galaxies[:5]
 ```
 
 ```{warning}
-Note that we use `to_table` above rather than `to_qtable`. While astropy's `QTable` is more powerful than its `Table`, as it e.g. handles the column units properly, we cannot use it here due to a known bug; it mishandles the large integer numbers in the `object_id` column and recast them as float during which process some precision is being lost. 
+Note that we use `to_table` above rather than `to_qtable`. While astropy's `QTable` is more powerful than its `Table`, as it e.g. handles the column units properly, we cannot use it here due to a known bug; it mishandles the large integer numbers in the `object_id` column and recast them as float during which process some precision is being lost.
 
 Once the bug is fixed, we plan to update the code in this notebook and simplify some of the approaches below.
 ```
@@ -263,9 +267,9 @@ For more info, please visit the [WCSAxes documentation](https://docs.astropy.org
 ```{code-cell} ipython3
 ax = plt.subplot(projection=cutout_image.wcs)
 
-ax.imshow(cutout_image.data, cmap='gray', origin='lower', 
+ax.imshow(cutout_image.data, cmap='gray', origin='lower',
           norm=ImageNormalize(cutout_image.data, interval=PercentileInterval(99.9), stretch=LogStretch()))
-plt.scatter(result_galaxies['ra'], result_galaxies['dec'], s=36, facecolors='none', edgecolors='red', 
+plt.scatter(result_galaxies['ra'], result_galaxies['dec'], s=36, facecolors='none', edgecolors='red',
             transform=ax.get_transform('world'))
 
 _ = plt.title('Galaxies between z = 1.4 and 1.6')
@@ -281,7 +285,7 @@ result_galaxies.sort(keys='flux_h_unif', reverse=True)
 result_galaxies[:3]
 ```
 
-Let's pick one of these galaxies. Note that the table has been sorted above, we can use the same index here and below to access the data for this particular galaxy. 
+Let's pick one of these galaxies. Note that the table has been sorted above, we can use the same index here and below to access the data for this particular galaxy.
 
 ```{code-cell} ipython3
 index = 2
@@ -363,7 +367,7 @@ Plot to show the cutout on the galaxy
 ```{code-cell} ipython3
 ax = plt.subplot(projection=cutout_galaxy.wcs)
 
-ax.imshow(cutout_galaxy.data, cmap='gray', origin='lower', 
+ax.imshow(cutout_galaxy.data, cmap='gray', origin='lower',
           norm=ImageNormalize(cutout_galaxy.data, interval=PercentileInterval(99.9), stretch=AsinhStretch()))
 ```
 

--- a/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
+++ b/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
@@ -50,7 +50,7 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 ## Imports
 
 ```{important}
-We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+We rely on ``astroquery`` features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
+++ b/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
@@ -48,6 +48,10 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 
 ## Imports
 
+```{important}
+We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+```
+
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed
 # !pip install matplotlib astropy 'astroquery>=0.4.10'

--- a/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
+++ b/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
@@ -49,7 +49,7 @@ If you have questions about this notebook, please contact the [IRSA helpdesk](ht
 ## Imports
 
 ```{important}
-We rely on astroquery features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
+We rely on ``astroquery`` features that have been recently added, so please make sure you have version v0.4.10 or newer installed.
 ```
 
 ```{code-cell} ipython3

--- a/tutorials/euclid_access/Euclid_ERO.md
+++ b/tutorials/euclid_access/Euclid_ERO.md
@@ -49,12 +49,17 @@ The total data volume required for running this notebook is less than 20 MB.
 
 ## Imports
 
-First, we import all necessary packages.
+```{important}
+We rely on astroquery, firefly_client, photutils, and sep features that have been recently added, so please make sure you have the respective versions v0.4.10, v3.2, v2.0, and v1.4 or newer installed.
+```
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
 # !pip install tqdm numpy matplotlib astropy 'photutils>=2.0' 'astroquery>=0.4.10' 'sep>=1.4' 'firefly_client>=3.2'
 ```
+
+First, we import all necessary packages.
+
 
 ```{code-cell} ipython3
 # General imports

--- a/tutorials/euclid_access/Euclid_ERO.md
+++ b/tutorials/euclid_access/Euclid_ERO.md
@@ -50,7 +50,7 @@ The total data volume required for running this notebook is less than 20 MB.
 ## Imports
 
 ```{important}
-We rely on astroquery, firefly_client, photutils, and sep features that have been recently added, so please make sure you have the respective versions v0.4.10, v3.2, v2.0, and v1.4 or newer installed.
+We rely on ``astroquery``, ``firefly_client``, ``photutils``, and ``sep`` features that have been recently added, so please make sure you have the respective versions v0.4.10, v3.2, v2.0, and v1.4 or newer installed.
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
I went with a 1 year cut-off date for the note, I think that's reasonable enough as a reminder. (we run into this issue with astroquery 0.4.10 a lot, I expect as it was released only a few days before the euclid release itself, but it came up with firefly previously).