### PR TITLE
MAINT: ray now has a py3.13 compatible release

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -13,7 +13,7 @@ hpgeom
 pandas>=1.5.2
 dask[distributed]
 psutil
-ray ; python_version < "3.13"
+ray
 s3fs
 firefly-client>=3.2.0
 jupyter-firefly-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,6 @@ commands =
     # too due to issues with e.g. multiprocessing and problems in upstream dependency
     !buildhtml: bash -c 'if python -c "import platform; print(platform.platform())" | grep -i macos; then cat ignore_osx_testing >> ignore_testing; fi'
     !buildhtml: bash -c 'if python -c "import platform; print(platform.platform())" | grep -i win; then cat ignore_windows_testing >> ignore_testing; fi'
-    # ray is not yet python 3.13 compatible
-    !buildhtml: bash -c 'if python -c "import sys; print(sys.version)" | grep 3.13; then echo Parallelize_Convolution.md >> ignore_testing; fi'
 
     !buildhtml: bash -c 'if [[ $CI == true ]]; then cat ignore_gha_testing >> ignore_testing; fi'
 


### PR DESCRIPTION
This PR removes the workaround we have for testing