### PR TITLE
Euclid MER catalog CMD: Reverse y-axis and zoom in

### DIFF
--- a/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
+++ b/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
@@ -151,8 +151,8 @@ plt.errorbar(x, y, xerr=xerr, yerr=yerr,
 
 plt.xlabel('Y-H')
 plt.ylabel('Y')
-plt.xlim(-10, 10)
-plt.ylim(10, 35)
+plt.xlim(-5, 5)
+plt.ylim(30, 15)
 plt.title('10k Stars in MER catalog -- IRSA')
 ```
 

--- a/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
+++ b/tutorials/euclid_access/2_Euclid_intro_MER_catalog.md
@@ -151,8 +151,9 @@ plt.errorbar(x, y, xerr=xerr, yerr=yerr,
 
 plt.xlabel('Y-H')
 plt.ylabel('Y')
-plt.xlim(-5, 5)
-plt.ylim(30, 15)
+# Note that these limits exclude a handful of points with large error bars.
+plt.xlim(-2, 2)
+plt.ylim(24, 16)
 plt.title('10k Stars in MER catalog -- IRSA')
 ```
 


### PR DESCRIPTION
In the Euclid MER catalog CMD figure, reverse the y-axis so that brighter stars are on top and zoom in to see detail a little better. The new figure looks like this (I can adjust x-and y-limits differently if wanted):

![cmd-10k-stars-in-mer](https://github.com/user-attachments/assets/9eedcc8a-41fe-46c9-8894-55adc109276f)