### PR TITLE
TMP: temporarily comment out list_collection calls

### DIFF
--- a/tutorials/cloud_access/euclid-cloud-access.md
+++ b/tutorials/cloud_access/euclid-cloud-access.md
@@ -115,12 +115,12 @@ coord = SkyCoord.from_name(target_name)
 search_radius = 10 * u.arcsec
 ```
 
-List all Simple Image Access (SIA) collections for IRSA with names containing "euclid":
-
-```{code-cell} ipython3
-collections = Irsa.list_collections(servicetype='SIA', filter='euclid')
-collections
-```
+% List all Simple Image Access (SIA) collections for IRSA with names containing "euclid":
+%
+% ```{code-cell} ipython3
+% collections = Irsa.list_collections(servicetype='SIA', filter='euclid')
+% collections
+% ```
 
 As per "Data Products Overview" in [user guide](https://irsa.ipac.caltech.edu/data/Euclid/docs/euclid_archive_at_irsa_user_guide.pdf) and above table, we identify that MER Mosiacs are available as the following collection:
 

--- a/tutorials/euclid_access/Euclid_ERO.md
+++ b/tutorials/euclid_access/Euclid_ERO.md
@@ -157,10 +157,10 @@ Note that the Euclid ERO images are no in the cloud currently, but we access the
 The following only works for combined images (either extended or point source stacks). This would not work if there are multiple, let's say, H-band images of Euclid at a given position. Therefore, no time domain studies here (which is anyway not one of the main goals of Euclid).
 ```
 
-The IRSA SIA products can be listed via
-```
-Irsa.list_collections(servicetype='SIA')
-```
+% The IRSA SIA products can be listed via
+% ```
+% Irsa.list_collections(servicetype='SIA')
+% ```
 
 Here we use the collection *euclid_ero*, containing the Euclid ERO images. We first create a `SkyCoord` object and then query the SIA.
 


### PR DESCRIPTION
This should fix/workaround the timeout issues we run into during the HTML builds. The reason is that astroquery is running a sync TAP query under the hood and the query is currently not cached on the server side.

We do fix this upstream in two, redundant ways:

- add caching on the server side
- change astroquery to use async TAP for `list_collections` (see https://github.com/astropy/astroquery/issues/3366)

In the meantime I remove these code cells from the notebooks so the rendered HTMLs can be updated.