### PR TITLE
Enable nb_scroll_outputs from latest myst-nb

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -45,6 +45,7 @@ exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache', 'README.
 nb_execution_timeout = 1200
 nb_merge_streams = True
 nb_execution_mode = "cache"
+nb_scroll_outputs = True
 
 nb_execution_excludepatterns = []
 

--- a/site_requirements.txt
+++ b/site_requirements.txt
@@ -1,4 +1,5 @@
 sphinx
-myst-nb
+# To pick up newest scroller and dark-mode features
+myst-nb>=1.3
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
~This PR is just a test for `scroll_outputs` functionality upcoming from upstream in https://github.com/executablebooks/MyST-NB/pull/683~

Fixes #69 

Test if the generated webpages have long outputs scrollable (bonus: also test dark mode style fixes that will come soon). 