### PR TITLE
Update Euclid spectra calls for new SpectrumDM service

### DIFF
--- a/tutorials/cloud_access/euclid-cloud-access.md
+++ b/tutorials/cloud_access/euclid-cloud-access.md
@@ -277,7 +277,7 @@ spec_association_tbl
 If you picked a target other than what this notebook uses, it's possible that there is no spectrum associated for your target's object ID. In that case, `spec_association_tbl` will contain 0 rows.
 ```
 
-In above table, we can see that the `'path'` column gives us a url that can be used to call an IRSA service to get the spectrum of our object. We can map it to an S3 bucket key to retrieve a spectra file from the cloud. This is a very big FITS spectra file with multiple extensions where each extension contains spectrum of one object. The `'hdu'` column gives us the extension number for our object. So let's extract both of these.
+In above table, we can see that the `'path'` column gives us a url that can be used to call an IRSA service to get the spectrum of our object as SpectrumDM VOTable. We can map it to an S3 bucket key to retrieve a spectra file from the cloud. This is a very big FITS spectra file with multiple extensions where each extension contains spectrum of one object. The `'hdu'` column gives us the extension number for our object. So let's extract both of these.
 
 ```{code-cell} ipython3
 spec_fpath_key = spec_association_tbl['path'][0].replace('api/spectrumdm/convert/euclid/', '').split('?')[0]

--- a/tutorials/cloud_access/euclid-cloud-access.md
+++ b/tutorials/cloud_access/euclid-cloud-access.md
@@ -277,7 +277,7 @@ spec_association_tbl
 If you picked a target other than what this notebook uses, it's possible that there is no spectrum associated for your target's object ID. In that case, `spec_association_tbl` will contain 0 rows.
 ```
 
-In above table, we can see that the `path` column gives us a url that can be used to call the SpectrumDM service to get the spectrum of our object. We can map it to an S3 bucket key to retrieve a spectra file from the cloud. This is a very big FITS spectra file with multiple extensions where each extension contains spectrum of one object. The `hdu` column gives us the extension number for our object. So let's extract both of these.
+In above table, we can see that the `'path'` column gives us a url that can be used to call an IRSA service to get the spectrum of our object. We can map it to an S3 bucket key to retrieve a spectra file from the cloud. This is a very big FITS spectra file with multiple extensions where each extension contains spectrum of one object. The `'hdu'` column gives us the extension number for our object. So let's extract both of these.
 
 ```{code-cell} ipython3
 spec_fpath_key = spec_association_tbl['path'][0].replace('api/spectrumdm/convert/euclid/', '').split('?')[0]

--- a/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
+++ b/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
@@ -55,8 +55,6 @@ We rely on ``astroquery`` features that have been recently added, so please make
 ```
 
 ```{code-cell} ipython3
-import urllib
-
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -100,7 +98,7 @@ result = Irsa.query_tap(adql_object).to_table()
 Pull out the file name from the ``result`` table:
 
 ```{code-cell} ipython3
-spectrum_path = urllib.parse.urljoin(Irsa.tap_url, result['path'][0])
+spectrum_path = f"https://irsa.ipac.caltech.edu/{result['path'][0]}"
 spectrum_path
 ```
 

--- a/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
+++ b/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
@@ -128,7 +128,7 @@ quantity_support()
 The 1D combined spectra table contains 6 columns, below are a few highlights:
 
 - WAVELENGTH is in Angstroms by default.
-- SIGNAL is the flux. The scale factor is included in the units.
+- SIGNAL is the flux. The values are scaled and the scaling factor is included in the column's units. This value corresponds to the `'FSCALE'` entry in the HDU header of the original FITS file.
 - MASK values can be used to determine which flux bins to discard. MASK = odd and MASK >=64 means the flux bins not be used.
 ```
 

--- a/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
+++ b/tutorials/euclid_access/4_Euclid_intro_PHZ_catalog.md
@@ -307,20 +307,18 @@ result_spectra
 Pull out the file name from the ``result_spectra`` table:
 
 ```{code-cell} ipython3
-file_uri = urllib.parse.urljoin(Irsa.tap_url, result_spectra['uri'][0])
-file_uri
+spectrum_path = f"https://irsa.ipac.caltech.edu/{result_spectra['path'][0]}"
+spectrum_path
 ```
 
 ```{code-cell} ipython3
-with fits.open(file_uri) as hdul:
-    spectrum = QTable.read(hdul[result_spectra['hdu'][0]], format='fits')
-    spectrum_header = hdul[result_spectra['hdu'][0]].header
+spectrum = QTable.read(spectrum_path)
 ```
 
 ### Now the data are read in, plot the spectrum
 
 ```{tip}
-As we use astropy.visualization’s quantity_support, matplotlib automatically picks up the axis units from the quantitites we plot.
+As we use astropy.visualization’s quantity_support, matplotlib automatically picks up the axis units from the quantities we plot.
 ```
 
 ```{code-cell} ipython3
@@ -418,8 +416,8 @@ fc.show_table(uploaded_table)
 
 ## About this Notebook
 
-**Author**: Tiffany Meshkat, Anahita Alavi, Anastasia Laity, Andreas Faisst, Brigitta Sipőcz, Dan Masters, Harry Teplitz, Jaladh Singhal, Shoubaneh Hemmati, Vandana Desai
+**Author**: Tiffany Meshkat, Anahita Alavi, Anastasia Laity, Andreas Faisst, Brigitta Sipőcz, Dan Masters, Harry Teplitz, Jaladh Singhal, Shoubaneh Hemmati, Vandana Desai, Troy Raen
 
-**Updated**: 2025-04-10
+**Updated**: 2025-09-24
 
 **Contact:** [the IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions or reporting problems.

--- a/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
+++ b/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
@@ -159,7 +159,7 @@ We specify the following conditions on our search:
 - Signal to noise ratio column (_gf = gaussian fit) should be greater than 5
 - We want to detect H-alpha.
 - We choose in which tileID to search, usign the tileID from the first notebook.
-- Choose spectroscopic redshift (spe_z) beween 1.4 and 1.6 and spe_z_prob greater than 0.999
+- Choose spectroscopic redshift (spe_z) between 1.4 and 1.6 and spe_z_prob greater than 0.999
 - H-alpha line flux should be more than 2x10^16 erg s^-1 cm^-2
 - Join the lines and galaxy candidates tables on object_id and spe_rank
 
@@ -208,23 +208,19 @@ result_table2 = Irsa.query_tap(adql_object).to_qtable()
 
 ### The following steps to read in the spectrum follows the 3_Euclid_intro_1D_spectra notebook.
 
-This involves reading in the spectrum without readin in the full FITS file, just pulling the extension we want.
-
 ```{code-cell} ipython3
-file_uri = urllib.parse.urljoin(Irsa.tap_url, result_table2['uri'][0])
-file_uri
+spectrum_path = urllib.parse.urljoin(Irsa.tap_url, result_table2['path'][0])
+spectrum_path
 ```
 
 ```{code-cell} ipython3
-with fits.open(file_uri) as hdul:
-    spectrum = QTable.read(hdul[result_table2['hdu'][0]], format='fits')
-    spec_header = hdul[result_table2['hdu'][0]].header
+spectrum = QTable.read(spectrum_path)
 ```
 
 ### Now the data are read in, plot the spectrum with the H-alpha line labeled
 
 ```{tip}
-As we use astropy.visualization's ``quantity_support``, matplotlib automatically picks up the axis units from the quantitites we plot.
+As we use astropy.visualization's ``quantity_support``, matplotlib automatically picks up the axis units from the quantities we plot.
 ```
 
 ```{code-cell} ipython3
@@ -248,8 +244,8 @@ plt.title(f'Object ID {obj_id}')
 
 ## About this Notebook
 
-**Author**: Tiffany Meshkat, Anahita Alavi, Anastasia Laity, Andreas Faisst, Brigitta Sipőcz, Dan Masters, Harry Teplitz, Jaladh Singhal, Shoubaneh Hemmati, Vandana Desai
+**Author**: Tiffany Meshkat, Anahita Alavi, Anastasia Laity, Andreas Faisst, Brigitta Sipőcz, Dan Masters, Harry Teplitz, Jaladh Singhal, Shoubaneh Hemmati, Vandana Desai, Troy Raen
 
-**Updated**: 2025-03-31
+**Updated**: 2025-09-23
 
 **Contact:** [the IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions or reporting problems.

--- a/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
+++ b/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
@@ -58,9 +58,6 @@ We rely on ``astroquery`` features that have been recently added, so please make
 ```
 
 ```{code-cell} ipython3
-import re
-import urllib
-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -209,7 +206,7 @@ result_table2 = Irsa.query_tap(adql_object).to_qtable()
 ### The following steps to read in the spectrum follows the 3_Euclid_intro_1D_spectra notebook.
 
 ```{code-cell} ipython3
-spectrum_path = urllib.parse.urljoin(Irsa.tap_url, result_table2['path'][0])
+spectrum_path = f"https://irsa.ipac.caltech.edu/{result_table2['path'][0]}"
 spectrum_path
 ```
 


### PR DESCRIPTION
[IRSA-7280](https://jira.ipac.caltech.edu/browse/IRSA-7280)

Starting on Wednesday, Sept 24, TAP calls for table 'euclid.objectid_spectrafile_association_q1' will return a `'path'` column instead of a `'uri'` column and it will contain a SpectrumDM url that will return a single spectrum instead of the full MEF. This PR updates our notebooks to accommodate.

To test: Before running any notebooks, create or edit the file `~/.astropy/config/astroquery.cfg` and make sure it has at least the following lines in it. Also make sure you're connected to IPAC VPN.

```
[ipac.irsa]
tap_url = https://irsadev.ipac.caltech.edu/TAP
```