### PR TITLE
MAINT: enlarge timeout for cosmodc2 notebook

### DIFF
--- a/tutorials/cosmodc2/cosmoDC2_TAP_access.md
+++ b/tutorials/cosmodc2/cosmoDC2_TAP_access.md
@@ -11,7 +11,7 @@ kernelspec:
   language: python
   name: python3
 execution:
-  timeout: 1600
+  timeout: 2600
 ---
 
 

--- a/tutorials/cosmodc2/cosmoDC2_TAP_access.md
+++ b/tutorials/cosmodc2/cosmoDC2_TAP_access.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+execution:
+  timeout: 1600
 ---
 
 
@@ -79,8 +81,8 @@ result = service.run_async(adql)
 result
 ```
 
-The above query shows that there are 597,488,849 redshifts in this table. 
-Running ``count`` on an entire table is an expensive operation, therefore we ran it asynchronously to avoid any potential timeout issues. 
+The above query shows that there are 597,488,849 redshifts in this table.
+Running ``count`` on an entire table is an expensive operation, therefore we ran it asynchronously to avoid any potential timeout issues.
 To learn more about synchronous versus asynchronous PyVO queries please read the [relevant PyVO documentation](https://pyvo.readthedocs.io/en/latest/dal/index.html#synchronous-vs-asynchronous-query).
 
 +++


### PR DESCRIPTION
This is a semi-dummy commit with the primary aim to to test cross-fork caching (and with a hopeful benefits of solving cosmodc2 timeouts)