### PR TITLE
Update spherex_qr -> spherex_qr2

### DIFF
--- a/tutorials/spherex/spherex_cutouts.md
+++ b/tutorials/spherex/spherex_cutouts.md
@@ -83,7 +83,6 @@ bandpass = 'SPHEREx-D2'
 output_filename = 'spherex_cutouts_mef.fits'
 ```
 
-(spherex-query-tap)=
 ## 5. Query IRSA for a list of cutouts that satisfy the criteria specified above.
 
 Here we show how to use the `pyvo` TAP SQL query to retrieve all images that overlap with the position defined above.
@@ -119,7 +118,7 @@ print("Number of images found: {}".format(len(results)))
 ```
 
 :::{note}
-SPHEREx data are also available via SIA which can provide a simpler interface for many queries, as demonstrated in {ref}`spherex-query-sia`.
+SPHEREx data are also available via SIA which can provide a simpler interface for many queries, as demonstrated in {ref}`spherex-intro`.
 An advantage of the method shown above is that it provides access to data immediately after ingestion (which occurs weekly) and is not subject to the same ~1 day delay as SIA.
 :::
 

--- a/tutorials/spherex/spherex_intro.md
+++ b/tutorials/spherex/spherex_intro.md
@@ -65,7 +65,6 @@ from astroquery.ipac.irsa import Irsa
 from firefly_client import FireflyClient
 ```
 
-(spherex-query-sia)=
 ## 5. Search for SPHEREx Spectral Image MEFs that overlap coordinates you are interested in
 
 +++
@@ -106,7 +105,7 @@ results = Irsa.query_sia(pos=(coord, search_radius), collection='spherex_qr2')
 :::{note}
 SPHEREx data are ingested on a weekly basis.
 Due to the nature of the ingestion process, availability via SIA will lag on the order of a day.
-To avoid this delay, users can access data through the browsable directories or the SPHEREx Data Explorer GUI (see [SPHEREx Data Access](https://caltech-ipac.github.io/spherex-archive-documentation/spherex-data-access)), or do a TAP query as shown in {ref}`spherex-query-tap`.
+To avoid this delay, users can access data through the browsable directories or the SPHEREx Data Explorer GUI (see [SPHEREx Data Access](https://caltech-ipac.github.io/spherex-archive-documentation/spherex-data-access)), or do a TAP query as shown in {ref}`spherex-cutouts`.
 :::
 
 Each row of the results of your query represents a different spectral image.

--- a/tutorials/spherex/spherex_psf.md
+++ b/tutorials/spherex/spherex_psf.md
@@ -107,6 +107,11 @@ print("Time to do TAP query: {:2.2f} seconds.".format(time.time() - t1))
 print("Number of images found: {}".format(len(results)))
 ```
 
+:::{note}
+SPHEREx data are also available via SIA which can provide a simpler interface for many queries, as demonstrated in {ref}`spherex-intro`.
+An advantage of the method shown above is that it provides access to data immediately after ingestion (which occurs weekly) and is not subject to the same ~1 day delay as SIA.
+:::
+
 For this example, we focus on the first one of the retrieved SPHEREx spectral images.
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Closes [IRSA-7323](https://jira.ipac.caltech.edu/browse/IRSA-7323)
Closes [IRSA-7363](https://jira.ipac.caltech.edu/browse/IRSA-7363)

Do not merge until SPHEREx QR2 has been released and is available in SIA.

SPHEREx QR2 is scheduled to be released on October ~~14~~16, available in SIA a day or two later. This PR updates notebooks to use it. I think that only the collections names will need to be updated but we'll need to test this once QR2 is available in SIA on irsatest, likely on October 13.