### PR TITLE
MAINT: back to use jupyter-book

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 
     buildhtml: bash -c "echo 'Notebooks ignored (not tested/executed) in this job:\n'; cat ignore_execute"
     # Using srtict so we fail with trackbacks and debug mode to have a richer log
-    buildhtml: bash -c "npx myst build --execute --html --strict -d"
+    buildhtml: bash -c "jupyter-book build --execute --html --strict -d"
 
 pip_pre =
     predeps: true


### PR DESCRIPTION
Apparently we have some issues about the paths/etc, so falling back on using JB to handle all the npm stuff and run the command alias. (We should have everything already installed, but GHA has issues picking up the command)

This should fix #167