### PR TITLE
Clarify that credentials are not required

### DIFF
--- a/tutorials/cloud_access/cloud-access-intro.md
+++ b/tutorials/cloud_access/cloud-access-intro.md
@@ -50,7 +50,7 @@ The cloud connection is handled by a separate library, usually [s3fs](https://s3
 The IRSA buckets are public and access is free.
 Credentials are not required.
 However, most tools will look for credentials by default and raise an error when none are found.
-To avoid this, users can make an "anonymous" connection, usually with a keyword argument such as `anon=True`.
+To access without credentials, users can make an anonymous connection, usually with a keyword argument such as `anon=True`.
 This notebook demonstrates with the `s3fs`, `astropy`, and `pyarrow` libraries.
 
 +++

--- a/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
+++ b/tutorials/parquet-catalog-demos/wise-allwise-catalog-demo.md
@@ -70,6 +70,7 @@ This AllWISE catalog is stored in an [AWS S3](https://aws.amazon.com/s3/) cloud 
 To connect to an S3 bucket we just need to point the reader at S3 instead of the local filesystem.
 (Here, a "reader" is a python library that reads parquet files.)
 We'll use [pyarrow.fs.S3FileSystem](https://arrow.apache.org/docs/python/generated/pyarrow.fs.S3FileSystem.html) for this because it is recognized by every reader in examples below, and we're already using pyarrow.
+([s3fs](https://s3fs.readthedocs.io/en/latest/index.html) is another common option.)
 To access without credentials, we'll use the keyword argument `anonymous=True`.
 More information about accessing S3 buckets can be found at [](#cloud-access-intro).
 


### PR DESCRIPTION
Text in the AllWISE parquet notebook makes it sound like AWS credentials are required, which they're not. This PR corrects that and also improves related languaging in the cloud access intro notebook. It also changes the AllWISE ODR link to point directly to the wise-allwise page (which didn't exist yet when the notebook was written) and removes a "Terminology" heading since the word tends to scare people off and the heading isn't necessary here anyway.