### PR TITLE
CI: cleanup running scenarios

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -5,8 +5,6 @@ on:
     branches:
     - main
   pull_request:
-    branches:
-    - main
   schedule:
     - cron: '0 5 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
~~DO NOT MERGE, using this PR as an experiment for some upstream issue (that so far hasn't affected us, thus we can help out numpy).~~ 


~~This is an alternative for #160 - we should be able to not doing the conditional (those would still show up as cancelled jobs, while they should not be triggered either)~~ This is not an alternative, currently the only alternative is that the fork owner manually disables actions on their fork.