### PR TITLE
MAINT: bumping firefly_client min version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     oldestdeps: astropy==5.3.0
     oldestdeps: photutils==2.0.0
     oldestdeps: astroquery==0.4.10
-    oldestdeps: firefly_client==3.2.0
+    oldestdeps: firefly_client==3.4.0
     oldestdeps: sep==1.4.0
     oldestdeps: pyvo==1.5.0
     oldestdeps: pandas==1.5.2


### PR DESCRIPTION
In general I don't think it's a good thing to require the latest and greatest version from any of the dependencies as it removes flexibility for user environments.

In this case firefly_client didn't change any of their requirements that we don't already have, so I think this is an OK PR to go ahead as is; but next time we may consider doing some version dependent usage/imports.

Resolves #173 