### PR TITLE
Fix workflow condition syntax

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   tests:
     # Do not run the test matrix on PRs affecting the rendering
-    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'html rendering / skip testing') && github.repository == 'Caltech-IPAC/irsa-tutorials' }}
+    if: ${{ (!(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'html rendering / skip testing')) && github.repository == 'Caltech-IPAC/irsa-tutorials' }}
 
     name: ${{ matrix.os }} ${{ matrix.name }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
#160 added conditions to prevent workflows from running in forks but it didn't fully work as intended. Some jobs kept running in my fork (e.g., https://github.com/troyraen/irsa-tutorials/actions/runs/19623883252). I think the problem is that `&&` binds more tightly than `||`, so the expression:

`!(github.event_name ... ) || !contains(...) && github.repository == 'Caltech-IPAC/irsa-tutorials'`

gets evaluate as:

`!(github.event_name ... ) || (!contains(...) && github.repository == 'Caltech-IPAC/irsa-tutorials')`

but what I intended was: 

`(!(github.event_name ... ) || !contains(...)) && github.repository == 'Caltech-IPAC/irsa-tutorials'`

This PR adds parentheses so the conditions are evaluated as intended.