### PR TITLE
hid the functions as drop downs

### DIFF
--- a/tutorials/roman_simulations/roman_hlss_number_density.md
+++ b/tutorials/roman_simulations/roman_hlss_number_density.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.18.1
 kernelspec:
-  display_name: python3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---


### PR DESCRIPTION
This will close the issue number 102 over in ipac-sp-notebooks. (closes https://github.com/IPAC-SW/ipac-sp-notebooks/issues/102)

That issue was to move the functions out of the notebook into a code_src type directory as we do for fornax-demo-notebooks, but I feel it is better to hide them in drop down menus.  I also believe the ESRR reviewers mentioned wanting to see the functions, but we also don't want to clutter the notebooks.  I feel hiding them in drop downs is a happy medium.

