### PR TITLE
CI: improve skipping logic

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,11 +67,11 @@ commands =
     # Make a list of all the tutorials to be reused in multiple filtering commands below
     bash -c 'find tutorials -name "*md" > all_tutorials'
 
-    # Make a list of the tutorials changed, we only need this in CI. At the end get rid of grep's return code for null match
-    bash -c 'if [[ $CI == true ]]; then git fetch origin main --depth=1; git diff origin/main --name-only tutorials | grep .md; else cat all_tutorials; fi | grep -vf ignore_testing || true > changed_tutorials'
+    # Make a list of the tutorials changed, we only need this in CI.
+    bash -c 'if [[ $CI == true ]]; then git fetch origin main --depth=1; git diff origin/main --name-only tutorials | grep .md; fi > changed_tutorials'
 
     # We only skip testing untouched tutorials in PRs; in cron and dispatch all should be tested
-    !buildhtml: bash -c 'if [[ $GITHUB_EVENT_NAME == pull_request && -z "$(grep force_run:all_tests ${GITHUB_EVENT_PATH})" ]]; then cat changed_tutorials; else cat all_tutorials; fi | xargs jupytext --to notebook '
+    !buildhtml: bash -c 'if [[ $GITHUB_EVENT_NAME == pull_request && -z "$(grep force_run:all_tests ${GITHUB_EVENT_PATH})" ]]; then cat changed_tutorials; else cat all_tutorials; fi | grep -vf ignore_testing | xargs jupytext --to notebook '
 
     !buildhtml: bash -c "echo 'Notebooks ignored (not tested/executed) in this job:\n'; cat ignore_testing"
     !buildhtml: pytest --nbval-lax -vv --suppress-no-test-exit-code --durations=10 tutorials


### PR DESCRIPTION
This should resolve https://github.com/Caltech-IPAC/irsa-tutorials/issues/143 and should fix https://github.com/IPAC-SW/ipac-sp-notebooks/issues/156

Note that this solution still assumes that we don't have any `execute` frontmatter for our notebooks, which current we don't have. Once we start using that for environment control we should update the regex logic, too.