### PR TITLE
BUG: do not run tests on non-notebook (landing) pages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ commands =
     buildhtml: bash -c 'cat ignore_tutorials/ignore_rendering_execution >> ignore_testing'
 
     # Make a list of all the tutorials to be reused in multiple filtering commands below
-    bash -c 'find tutorials -name "*md" > all_tutorials'
+    bash -c 'find tutorials -name "*md" | xargs grep kernelspec: | awk -F :kernelspec: "{print \$1}" > all_tutorials'
 
     # Make a list of the tutorials changed, we only need this in CI. Also deal with grep's non-zero exit code.
     bash -c 'if [[ $CI == true ]]; then git fetch origin main --depth=1; git diff origin/main --name-only tutorials | grep ".md" || true; fi > changed_tutorials'


### PR DESCRIPTION
pytest should really not care about the landing pages (run into it in https://github.com/Caltech-IPAC/irsa-tutorials/pull/193#issuecomment-3684074984)