### PR TITLE
Use query_ssa() for Euclid tutorials 3 & 5

### DIFF
--- a/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
+++ b/tutorials/euclid_access/3_Euclid_intro_1D_spectra.md
@@ -1,4 +1,5 @@
 ---
+short_title: "SIR 1D Spectra"
 jupytext:
   text_representation:
     extension: .md

--- a/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
+++ b/tutorials/euclid_access/5_Euclid_intro_SPE_catalog.md
@@ -1,4 +1,5 @@
 ---
+short_title: "SPE Catalogs"
 jupytext:
   text_representation:
     extension: .md
@@ -223,7 +224,7 @@ obj_row
 euclid_ssa_collection = "euclid_DpdSirCombinedSpectra"
 
 # Use the object's MER coordinates from obj_row
-coord_obj = SkyCoord(obj_row["ra"], obj_row["dec"], unit=u.deg)
+coord_obj = SkyCoord(obj_row["ra"][0], obj_row["dec"][0], unit=u.deg)
 
 #complete the query
 ssa_result = Irsa.query_ssa(


### PR DESCRIPTION
Mostly just updated  to use the IRSA preferred query_ssa() to look for spectra.

For notebook 3, I switched from searching for a spectrum by objectID to searching by coords.  I feel this is a more generically useful approach. 

Minor other changes:
- updated date
- updated author list
- cleaned up goals for 3rd notebook to reflect notebook (I think they were copied from a different notebook and never checked)


This will close #141 