### PR TITLE
Hide footer links as they have a buggy behaviour with TOC nesting

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -27,3 +27,5 @@ site:
     favicon: _static/irsa-favicon.ico
     logo: _static/irsa_logo.png
     outline_maxdepth: 1
+    # Keep the footer links hidden at least until https://github.com/jupyter-book/mystmd/issues/2589 is resolved
+    hide_footer_links: true


### PR DESCRIPTION
This is to close #228 as a workaround for https://github.com/jupyter-book/mystmd/issues/2589

