### PR TITLE
MAINT: turning off parallel execution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,8 +86,10 @@ commands =
     buildhtml: bash -c 'if [ -s ignore_execute ]; then for name in $(cat ignore_execute | sort| uniq); do if [ -z "$(head -n 20 ${name}| grep execute:)" ]; then sed -i -e "s|kernelspec:|execute:\n  skip: true\nkernelspec:|g" ${name}; fi; done;fi'
 
     buildhtml: bash -c "echo 'Notebooks ignored (not tested/executed) in this job:\n'; cat ignore_execute"
+
     # Using srtict so we fail with trackbacks and debug mode to have a richer log
-    buildhtml: bash -c "jupyter-book build --execute --html --strict -d"
+    # For full build we disable parallel runs to easy server load
+    buildhtml: bash -c "jupyter-book build --execute --execute-parallel 1 --html --strict -d"
 
 pip_pre =
     predeps: true


### PR DESCRIPTION
This may help a little bit with server load issues we experience, but also my high expectation is that this will help on circleCI where we keep hitting memory limits --> we can turn execution for more notebooks from `ignore_tutorials/ignore_circleci_testing`