### PR TITLE
Enable execution on CircleCI for more notebooks

### DIFF
--- a/ignore_tutorials/ignore_circleci_testing
+++ b/ignore_tutorials/ignore_circleci_testing
@@ -1,13 +1,8 @@
-# ignore these 10 now as excluding execution for these is a combination that passes JB2 building on CircleCI.
-# Note that the first 2 are excluded for all kinds of testing; while the parallelize causes issues for GHA JB2 builds and non linux testing, too.
+# ignore these as they run out of resources on CircleCI.
+# Note that we don't duplicate the listing of notebooks that are ignored for all types of testing.
 #
-tutorials/euclid/euclid-cloud-access
-tutorials/simulated-data/cosmoDC2_TAP_access
 tutorials/simulated-data/openuniverse2024_roman_simulated_timedomainsurvey
 tutorials/simulated-data/openuniverse2024_roman_simulated_wideareasurvey
 tutorials/simulated-data/roman_hlss_number_density
+tutorials/euclid/euclid-cloud-access
 tutorials/techniques-and-tools/cloud-access-intro
-tutorials/techniques-and-tools/Parallelize_Convolution
-tutorials/wise/neowise-source-table-lightcurves
-tutorials/wise/neowise-source-table-strategies
-tutorials/wise/wise-allwise-catalog-demo


### PR DESCRIPTION
This requires circleCI specific testing via an SSH session as well as disabling a lot of the test skip logic, leaving as draft while iterating on it.

This closes #209 