### PR TITLE
Adding jupytext config 

### DIFF
--- a/jupytext.toml
+++ b/jupytext.toml
@@ -1,0 +1,1 @@
+notebook_metadata_filter="all,-language_info"


### PR DESCRIPTION
to ensure metadata is not cleared out unintentionally

This is a bit annoying solution, but I didn't find any other way for now. I confirmed this to work with being in the root of the tutorials for a jupyterlab session; but it doesn't work when someone directly opens the notebooks with `jupyter notebook <full_path_to_notebook>`, for that scenario the config needs to be next to the notebook.

Anyway, I don't think anyone besides me uses that way and getting this fixed up for fornax will actually be helpful.

@jkrick - can I double check if you use your own repo checkout on fornax? If yes, then we should be all set with this, but if you use any of the fornax deployed/copied notebooks then this file needs to be put in the deployed manifest, too.