### PR TITLE
Sia v2  cleanup

### DIFF
--- a/tutorials/wise/sia_allwise_atlas.md
+++ b/tutorials/wise/sia_allwise_atlas.md
@@ -2,7 +2,7 @@
 authors:
 - name: IRSA Data Science Team
 - name: Troy Raen
-- name: "Brigitta Sip\u0151cz"
+- name: "Brigitta Sipőcz"
 - name: Jessica Krick
 - name: Andreas Faisst
 - name: Jaladh Singhal


### PR DESCRIPTION
closes #240 
closes #106 

This completely re-works the SIA_allwise notebook to be both functional and follow what I think are best practices for accessing IRSA SIA v2 datasets.  It also now conforms to the template format for this repo. 

The old notebook was neither functional nor followed current best practices.  