### PR TITLE
Remove matplotlib dependency

### DIFF
--- a/tutorials/spherex/spherex_source_discovery/conda-spherex_sdt.yml
+++ b/tutorials/spherex/spherex_source_discovery/conda-spherex_sdt.yml
@@ -8,7 +8,6 @@ dependencies:
   - bokeh
   - ipykernel
   - ipywidgets
-  - matplotlib
   - numpy
   - pandas
   - photutils


### PR DESCRIPTION
The environment created by `conda-sphere_sdt.yml` for the SPHEREx source discovery tool is about 1.2G. That's pretty large, which makes it more cumbersome to work with. I looked into whether we could reduce the size and found that matplotlib is being installed but not used. Removing it reduces the size of the environment by about a third, down to 770M.

I tested this on fornax and see no difference in the source discovery tool notebook when running in an environment built by the current `conda-sphere_sdt.yml` vs the one in this PR that removes matplotlib. I'm checking with @afaisst to make sure I'm not missing something.