### PR TITLE
Catch spherex read errors

### DIFF
--- a/tutorials/spherex/spherex_cutouts.md
+++ b/tutorials/spherex/spherex_cutouts.md
@@ -384,7 +384,7 @@ plt.show()
 
 ## About this notebook
 
-**Updated:** 24 October 2025
+**Updated:** 5 March 2026
 
 **Contact:** [IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions or problems.
 

--- a/tutorials/spherex/spherex_intro.md
+++ b/tutorials/spherex/spherex_intro.md
@@ -474,6 +474,6 @@ print("Dimensions of VALUES array:",  wavelengths.shape)
 **Contact:** [IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions
 or problems.
 
-**Updated:** 24 October 2025
+**Updated:** 5 March 2026
 
 **Runtime:** approximately 30 seconds

--- a/tutorials/spherex/spherex_psf.md
+++ b/tutorials/spherex/spherex_psf.md
@@ -317,7 +317,7 @@ To use this PSF for forward modeling or fitting, you must:
 
 ## About this notebook
 
-**Updated:** 24 October 2025
+**Updated:** 5 March 2026
 
 **Contact:** Contact [IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions or problems.
 


### PR DESCRIPTION
Closes #165 

For SPHEREx Intro and PSF notebooks, this catches the three errors seen in #165 and retries a few times. The notebooks can't continue without the data, so need to retry rather than just pass.

For SPHEREx Cutouts notebook, this adds a wrapper function that catches the three errors seen in #165 and just passes. The notebook gets a bunch of cutouts, so passing a few should be fine. This notebook also sometimes fails later on after cutouts have been retrieved with a `TypeError: 'NoneType' object is not iterable` (seen in builds linked from #165 but weren't copied directly into the issue). I'm pretty sure that's happening for the same reasons, it's just that the errors are getting lost in the background during the parallel processing. In any case, this PR handles them by dropping `None`s from the table.

These changes aren't guaranteed to make the notebooks run if, for example, the service is having an extra hard time. We can increase the number of retries and/or add more error codes to catch in the future if needed.