### PR TITLE
MAINT: temporarily ignore GH links, remove exception for IVOA

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -23,6 +23,9 @@ project:
        keys:
          # These link resolve in the browser but generates did not resolve and 403 for the build
          - https://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan?projshort=SPITZER
+         # GH is rather flaky for CI right now, temporarily measure
+         - 'https://github.com/**'
+         
 extends:
   - toc.yml
 site:


### PR DESCRIPTION
Reverts Caltech-IPAC/irsa-tutorials#272 as upstream server is back online.

It also adds a temp ignore for GH links as currently those are blocking all the testing and deployments. More context in #277 