### PR TITLE
Add one-sentence description for Euclid galaxy clusters tutorial

### DIFF
--- a/notebook_metadata.yml
+++ b/notebook_metadata.yml
@@ -22,6 +22,9 @@
 - title: Euclid Cloud Access
   file: tutorials/euclid/euclid-cloud-access.md
   description: Browse the on-cloud copy of Q1, then efficiently retrieve a MER mosaic cutout and a SIR spectrum.
+- title: Galaxy Clusters
+  file: tutorials/euclid/euclid_clusters_tutorial.md
+  description: Use Euclid Q1 data to detect and validate a galaxy cluster.
 - title: HATS with LSDB
   file: tutorials/techniques-and-tools/irsa-hats-with-lsdb.md
   description: Use LSDB for user-friendly cross matching and querying of HATS Collections.

--- a/tutorials/euclid/euclid.md
+++ b/tutorials/euclid/euclid.md
@@ -66,6 +66,12 @@ Browse the on-cloud copy of Q1, then efficiently retrieve a MER mosaic cutout an
 ```
 
 ```{card}
+:link: euclid_clusters_tutorial.md
+:header: [Galaxy Clusters →](euclid_clusters_tutorial.md)
+Use Euclid Q1 data to detect and validate a galaxy cluster.
+```
+
+```{card}
 :link: Euclid_ERO.md
 :header: [ERO Star Clusters →](Euclid_ERO.md)
 Create multi-wavelength ERO image cutouts of a globular cluster, extract sources, and measure photometry. Match Gaia sources with Euclid ERO catalogs, then visualize with Firefly.


### PR DESCRIPTION
Adds a one-sentence description for the Euclid galaxy clusters tutorial (euclid_clusters_tutorial.md, from bsipocz's ENH_euclid_clusters branch) to the two relevant files:               
  - notebook_metadata.yml — new entry with title "Galaxy Clusters" and description                                                                                                          
  - tutorials/euclid/euclid.md — new card linking to the tutorial                                                                                                                           
                                                                                                                                                                                            
  Description used: "Use Euclid Q1 data to detect and validate a galaxy cluster."  

Closes #283 