### PR TITLE
Issue 276 (PSF header update)

### DIFF
--- a/tutorials/spherex/spherex_psf.md
+++ b/tutorials/spherex/spherex_psf.md
@@ -58,7 +58,7 @@ The following packages must be installed to run this notebook.
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# !pip install astropy numpy pyvo
+# !pip install astropy matplotlib numpy pyvo
 ```
 
 ```{code-cell} ipython3
@@ -630,7 +630,7 @@ To use this PSF for forward modeling or fitting, you must:
 
 ## About this notebook
 
-**Updated:** 10 March 2026
+**Updated:** 13 March 2026
 
 **Contact:** Contact [IRSA Helpdesk](https://irsa.ipac.caltech.edu/docs/help_desk.html) with questions or problems.
 


### PR DESCRIPTION
PR for issue https://github.com/Caltech-IPAC/irsa-tutorials/issues/276.

Changes:
* Added warning that PSF header needs to be updated for data versions <=6.5.5. Added link to PSF Erratum (webpage still needs to be added)
* Added learning goal: learn which version of the data you are looking at, and how to use this version information to correctly interpret the PSF extension of the SPHEREx spectral images.
* Added check for SPHEREx image version to notify user if the PSF header needs to be updated.
* Added function to update PSF header to fix incorrectly described zone centers. Tell use that PSF needs to be updated if version <=6.5.5. The function corrects the PSF header and updates version in primary header.
* Added note that number of PSF zones can change in later pipeline versions


Todo:
* move the function that updates the PSF header (pretty long, might want to put it somewhere else and then import) to another python file within the repo

