### PR TITLE
Sync notebook_metadata.yml with landing pages

### DIFF
--- a/notebook_metadata.yml
+++ b/notebook_metadata.yml
@@ -3,19 +3,19 @@
   description: Retrieve coadded images and make coordinate-based cutouts.
 - title: AllWISE Source Catalog
   file: tutorials/wise/wise-allwise-catalog-demo.md
-  description: Explore mid-infrared source properties by querying, filtering, and working with the catalog.
-- title: Cloud Access Intro
+  description: Query the Parquet copy of the AllWISE Source Catalog.
+- title: Cloud Access
   file: tutorials/techniques-and-tools/cloud-access-intro.md
-  description: Learn how to access and work with data served by IRSA from AWS S3 cloud storage.
+  description: Access and work with data served by IRSA from AWS S3 cloud storage.
 - title: CosmoDC2 Data Access
   file: tutorials/simulated-data/cosmoDC2_TAP_access.md
-  description: Access, query, and visualize the catalog.
+  description: Access, query, and visualize the CosmoDC2 catalog.
 - title: COSMOS Images
   file: tutorials/cosmos/sia_v1_cosmos.md
   description: Query IRSA's SIA service for COSMOS images and create and display a cutout.
 - title: Data Overview
   file: tutorials/spherex/spherex_intro.md
-  description: Learn about available data including how to identify which files and formats are appropriate for different use cases.
+  description: Find Spectral Images that overlap a sky position and understand the structure of the Multi-Extension FITS files.
 - title: Early Release Observations (ERO) - Star Clusters
   file: tutorials/euclid/Euclid_ERO.md
   description: Create multi-wavelength ERO image cutouts of a globular cluster, extract sources, and measure photometry. Match Gaia sources with Euclid ERO catalogs, then visualize with Firefly.
@@ -25,16 +25,16 @@
 - title: HATS with LSDB
   file: tutorials/techniques-and-tools/irsa-hats-with-lsdb.md
   description: Use LSDB for user-friendly cross matching and querying of HATS Collections.
-- title: Introduction
+- title: 'Merged Objects Catalog: Introduction'
   file: tutorials/euclid/merged-objects-hats-catalog/1-euclid-q1-hats-intro.md
   description: Understand the content and format of the Euclid Q1 Merged Objects HATS Catalog, then perform a basic query.
-- title: Magnitudes
+- title: 'Merged Objects Catalog: Magnitudes'
   file: tutorials/euclid/merged-objects-hats-catalog/4-euclid-q1-hats-magnitudes.md
   description: Review the types of flux measurements available, load template-fit and aperture magnitudes, and plot distributions and comparisons for different object types.
 - title: MER Catalogs
   file: tutorials/euclid/2_Euclid_intro_MER_catalog.md
   description: Explore the columns in the MER final catalog, query for stars, and create a color-magnitude diagram.
-- title: MER Mosaics
+- title: MER Image Mosaics
   file: tutorials/euclid/1_Euclid_intro_MER_images.md
   description: Retrieve both a full MER mosaic image and multi-wavelength cutouts, then subtract the background from the cutouts and extract sources.
 - title: NEOWISE Light Curves
@@ -51,7 +51,7 @@
   description: Access OpenUniverse2024 wide-area simulated survey data.
 - title: OpenUniverse2024 Time Domain
   file: tutorials/simulated-data/openuniverse2024_roman_simulated_timedomainsurvey.md
-  description: Access and analyze the time-domain survey.
+  description: Access and analyze the simulated time-domain OpenUniverse2024 survey.
 - title: OpenUniverse2024 Visualization
   file: tutorials/simulated-data/OpenUniverse2024Preview_Firefly.md
   description: Use Firefly to get an overview of survey structure and visualize content.
@@ -63,13 +63,13 @@
   description: Join the PHZ and MER catalogs to query galaxies with quality redshifts in a box region, create MER mosaic cutouts with catalog overlays, and plot the brightest galaxy's SIR spectrum.
 - title: PSF Models
   file: tutorials/spherex/spherex_psf.md
-  description: Learn how SPHEREx point spread function (PSF) information is organized and accessed.
+  description: Understand how SPHEREx point spread function (PSF) information is organized and accessed.
 - title: Roman HLSS Number Density
   file: tutorials/simulated-data/roman_hlss_number_density.md
   description: Query the catalog and derive galaxy number density.
 - title: SED Visualization
   file: tutorials/techniques-and-tools/SEDs_in_Firefly.md
-  description: Explore and interactively visualize SEDs using Firefly on multi-wavelength datasets.
+  description: Explore and interactively visualize multi-wavelength SEDs using Firefly.
 - title: SIR 1D Spectra
   file: tutorials/euclid/3_Euclid_intro_1D_spectra.md
   description: Load a galaxy spectrum and plot it. Understand the wavelength, flux, and mask values.

--- a/tutorials/simulated-data/simulated.md
+++ b/tutorials/simulated-data/simulated.md
@@ -5,12 +5,12 @@ Because this collection is heterogeneous in coverage, structure, and intended us
 Access methods are tailored to the structure and scale of each product.
 These tutorials are designed to help users get started with accessing, visualizing, and analyzing simulated datasets hosted at IRSA.
 
-- [Roman HLSS Number Density](roman_hlss_number_density.md) - Illustrate how to query the catalog and derive galaxy number density.
+- [Roman HLSS Number Density](roman_hlss_number_density.md) - Query the catalog and derive galaxy number density.
 
 - [OpenUniverse2024 Roman Coadds](openuniverse2024_roman_simulated_wideareasurvey.md) - Access OpenUniverse2024 wide-area simulated survey data.
 
 - [OpenUniverse2024 Visualization](OpenUniverse2024Preview_Firefly.md) - Use Firefly to get an overview of survey structure and visualize content.
 
-- [OpenUniverse2024 Time Domain](openuniverse2024_roman_simulated_timedomainsurvey.md) - Access and analyze time-domain OpenUniverse2024 survey.
+- [OpenUniverse2024 Time Domain](openuniverse2024_roman_simulated_timedomainsurvey.md) - Access and analyze the simulated time-domain OpenUniverse2024 survey.
 
 - [CosmoDC2 Data Access](cosmoDC2_TAP_access.md) - Access, query, and visualize the CosmoDC2 catalog.

--- a/tutorials/spherex/spherex.md
+++ b/tutorials/spherex/spherex.md
@@ -6,7 +6,7 @@ Its science goals span cosmology, galaxy evolution, and the interstellar medium,
 
 SPHEREx data releases include weekly [Quick Release spectral image products](https://caltech-ipac.github.io/spherex-archive-documentation/spherex-data-products/) (multi-extension FITS files containing calibrated near-infrared surface brightness, variance, flags, modeled backgrounds, PSFs, and wavelength WCS) along with ancillary calibration and metadata files such as gain matrices, dark current maps, solid angle pixel maps, and detailed spectral WCS products for each detector.
 
-- [Data Overview](spherex_intro.md) - Identify available data products and select the appropriate FITS extensions for different use cases.
+- [Data Overview](spherex_intro.md) - Find Spectral Images that overlap a sky position and understand the structure of the Multi-Extension FITS files.
 
 - [Spectral Image Cutouts](spherex_cutouts.md) - Generate and work with spatial and spectral cutouts.
 

--- a/tutorials/techniques-and-tools/techniques.md
+++ b/tutorials/techniques-and-tools/techniques.md
@@ -9,4 +9,4 @@ This collection includes guidance on cloud-based data access, use of powerful bi
 
 - [SED Visualization](SEDs_in_Firefly.md) - Explore and interactively visualize multi-wavelength SEDs using Firefly.
 
-- [Parallelization](Parallelize_Convolution.md) - Apply parallelization techniques to speed up operations on large astronomical images.
+- [Parallelization](Parallelize_Convolution.md) - Learn parallelization techniques to speed up operations on large astronomical images.

--- a/tutorials/wise/wise.md
+++ b/tutorials/wise/wise.md
@@ -3,16 +3,15 @@
 The Wide-field Infrared Survey Explorer ([WISE](https://irsa.ipac.caltech.edu/Missions/wise.html)) is a NASA infrared space telescope launched in December 2009 that performed a sensitive all-sky survey at 3.4, 4.6, 12, and 22 µm, cataloging hundreds of millions of stars, galaxies, and Solar System objects and enabling discoveries of cool brown dwarfs and luminous infrared galaxies.
 After exhausting its cryogen, the mission was repurposed as NEOWISE in 2013 to detect and characterize near-Earth asteroids and comets using the remaining infrared channels until the mission concluded in August 2024.
 
-
 WISE and NEOWISE data are released publicly through the NASA/IPAC Infrared Science Archive (IRSA), including calibrated images, source catalogs, and single-exposure source tables that together enable multi-epoch photometry, light curves, and motion studies for a wide range of astrophysical and Solar System applications.
 Successive NEOWISE data releases, issued with annual updates, provided users with increasingly deep coverage and time-domain information across the infrared sky.
 
 - [AllWISE Images](sia_allwise_atlas.md) - Retrieve coadded images and make coordinate-based cutouts.
 
-- [AllWISE Catalog](wise-allwise-catalog-demo.md) - Querying, filter, and work with a HEALPix-partitioned Parquet catalog using the AllWISE dataset.
+- [AllWISE Source Catalog](wise-allwise-catalog-demo.md) - Query the Parquet copy of the AllWISE Source Catalog.
 
-- [NEOWISE Firefly](NEOWISE_light_curve_demo.md) - Visualize and analyze light curves of Solar System objects using Firefly.
+- [NEOWISE Solar System Objects](NEOWISE_light_curve_demo.md) - Visualize and analyze light curves of Solar System objects using Firefly.
 
-- [NEOWISE Strategies](neowise-source-table-strategies.md) - Use efficient strategies for accessing and handling the very large Parquet dataset.
+- [NEOWISE Strategies](neowise-source-table-strategies.md) - Learn efficient strategies for accessing and handling this very large Parquet dataset.
 
 - [NEOWISE Light Curves](neowise-source-table-lightcurves.md) - Build multi-epoch photometric light curves for given coordinates.


### PR DESCRIPTION
The titles and descriptions of notebook_metadata.yml fell out of sync with the landing pages. This syncs them back up. 

It won't be necessary to do this after #233.