### PR TITLE
Bug fix and update in calculation of PSF zones

### DIFF
--- a/tutorials/spherex/spherex_psf.md
+++ b/tutorials/spherex/spherex_psf.md
@@ -3,7 +3,7 @@ authors:
 - name: Vandana Desai
 - name: Jessica Krick
 - name: Andreas Faisst
-- name: "Brigitta Sip\u0151cz"
+- name: "Brigitta Sipőcz"
 - name: Troy Raen
 jupytext:
   text_representation:
@@ -637,6 +637,3 @@ To use this PSF for forward modeling or fitting, you must:
 
 **Runtime:** Approximately 30 seconds.
 
-```{code-cell} ipython3
-
-```


### PR DESCRIPTION
While the zone pixel coordinate centers are 0-based, their names in the header (XCTR_1, etc) are 1-based.
This has been clarified in the text. Furthermore, the formula for the calculation of the distance between pixel and PSF zone centers has been updated to account for 0-based indexing.

Linked to issue, closes https://github.com/Caltech-IPAC/irsa-tutorials/issues/289