### PR TITLE
CI: we should not run tests with problematic manifests

### DIFF
--- a/.github/workflows/ci_tests_run_notebooks.yml
+++ b/.github/workflows/ci_tests_run_notebooks.yml
@@ -48,7 +48,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Validating manifest
-        if:  ${{ matrix.os == 'ubuntu-latest' }}
         run: bash -c 'missing=false; for file in $(cat deploy_to_fornax_manifest.in); do if [ ! -f $file ]; then echo "Inconsistent" $file; missing=true; fi; done; if $missing; then exit 1; fi'
 
       - name: Install dependencies


### PR DESCRIPTION
There was some windows specific problems, but ideally those should be worked out and we should always abort early to avoid unnecessary server load if there are problems with the manifest


draft as with no access to windows I need to debug it here