### PR TITLE
Update path to SPHEREx mosaic cube data file

### DIFF
--- a/tutorials/spherex/spherex_mosaic.md
+++ b/tutorials/spherex/spherex_mosaic.md
@@ -117,7 +117,7 @@ To retrieve the same mosaic as provided here, go to the [IRSA mosaic tool](https
 We first define the path to the mosaic cube.
 
 ```{code-cell} ipython3
-fn_spherex = "https://irsa.ipac.caltech.edu/onlinehelp/spherex/spherex/M101_irsa.fits"
+fn_spherex = "https://irsa.ipac.caltech.edu/data/demos/notebooks/spherex/M101_irsa.fits"
 ```
 
 Next, we open the image and convert the flux units from MJy/sr to mJy:


### PR DESCRIPTION
We have a new space to store data files needed for notebooks: https://irsa.ipac.caltech.edu/data/demos/notebooks/.

The `M101_irsa.fits` file used by the mosaic cubes notebook is there now. This PR updates the notebook to use it.