### PR TITLE
Caching improvements

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 8 * * 5'
   workflow_dispatch:
 
 concurrency:
@@ -20,7 +22,6 @@ jobs:
 
   publish_html:
     if: >-
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'Caltech-IPAC/irsa-tutorials'
 
@@ -37,11 +38,21 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade tox
 
+      # We use the cache conditionally dependencing on the trigger event, keep it read only for cron
       - name: Using execution-output cache
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: _build/execute
           key: JB-output-${{ github.run_id }}
+          kestore-keys: |
+            JB-output-
+
+      - name: Using execution-output cache for cron
+        if: (github.event_name == 'schedule' ))
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: _build/execute
           kestore-keys: |
             JB-output-
 
@@ -57,6 +68,7 @@ jobs:
           path: ./_build
 
       - name: Publish
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -49,7 +49,7 @@ jobs:
             JB-output-
 
       - name: Using execution-output cache for cron
-        if: (github.event_name == 'schedule' ))
+        if: (github.event_name == 'schedule' )
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: _build/execute

--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: _build/execute
-          key: JB-output
+          key: JB-output-${{ github.run_id }}
+          kestore-keys: |
+            JB-output-
 
       - name: Execute notebooks while building HTMLs
         run: tox -e py312-buildhtml


### PR DESCRIPTION
This PR works towards addressing items from https://github.com/IPAC-SW/irsa-datascience/issues/191. 

I'm doing the changes as part of a PR for transparency, but the job is not triggered for PRs and making it temporarily would not actually test most of the logics, so I'll just YOLO merge the PR and maybe push a direct follow-up commit if necessary.

The reasoning for the changes:

- adding the cron trigger in order to ensure the cache is being used at least once in every 7 days to avoid its automated cleanup. This job actually expected to do nothing as everything should be pulled in from the cache. 
- using unique cache keys so the updated cache is being saved

Still outstanding things: use the DOI lookup cache in addition to the execution cache.