### PR TITLE
CI:  always refresh cache, even from cron

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -38,21 +38,12 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade tox
 
-      # We use the cache conditionally dependencing on the trigger event, keep it read only for cron
       - name: Using execution-output cache
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: _build/execute
           key: JB-output-${{ github.run_id }}
-          restore-keys: |
-            JB-output-
-
-      - name: Using execution-output cache for cron
-        if: (github.event_name == 'schedule' )
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: _build/execute
           restore-keys: |
             JB-output-
 


### PR DESCRIPTION
Seeing the failure modes in the past few weeks, actually I think we can save out the cache even from the cron job -- if any of the executions have issues it won't generate a new output, so overall I think we will be fine with this strategy; and config is cleaner and more failure proof.

Opening the PR for transparency, but merging it away as it has no affect on any of the workflows triggered for PRs.