### PR TITLE
Fixing the hidden code and figure cells in the Euclid q1 hats magntitude webpage

### DIFF
--- a/tutorials/euclid/merged-objects-hats-catalog/4-euclid-q1-hats-magnitudes.md
+++ b/tutorials/euclid/merged-objects-hats-catalog/4-euclid-q1-hats-magnitudes.md
@@ -232,7 +232,7 @@ Since the template-fit photometry is recommended for extended objects, we'll sep
 ---
 jupyter:
   source_hidden: true
-tags: [hide-cell]
+tags: [hide-input]
 ---
 # Galaxy + any. Star + galaxy. QSO + galaxy.
 classes = {"Galaxy": (2, 3, 6, 7), "Star": (1, 3), "QSO": (4, 6)}
@@ -305,7 +305,7 @@ This figure is inspired by Romelli Fig. 6 (top panel).
 ---
 jupyter:
   source_hidden: true
-tags: [hide-cell]
+tags: [hide-input]
 ---
 # Only consider objects within these mag and mag difference limits.
 mag_limits, mag_diff_limits = (16, 24), (-1, 1)


### PR DESCRIPTION
## Summary

This PR fixes the hidden code and figure cells in the Euclid Q1 HATS magnitudes tutorial page.

The figure outputs were being placed inside cells using `hide-cell`, which caused both the code and output figure to be hidden by default. These have been changed to `hide-input` so that only the figure output is displayed.

This issue was left over from #335.

## Related issue

Closes #361.

## Testing procedure

- Created an environment using `tutorial_requirements.txt` and `site_requirements.txt`.
- Built the documentation locally with Jupyter Book using the execution and strict-build options.
- Served the generated HTML locally and verified that the figure is displayed and the code remains hidden.